### PR TITLE
Add MQTT encryption and authentication

### DIFF
--- a/arduino_secrets.h.example
+++ b/arduino_secrets.h.example
@@ -3,3 +3,12 @@
 #define SECRET_MQTT_BROKER "192.168.1.2"
 #define SECRET_MQTT_PORT 1883
 #define SECRET_MQTT_TOPIC "some/topic"
+/* If you enabled MQTT_TLS, fill in your server certificate fingerprint.
+ * If the SHA1 fingerprint of your certificate is 01:02:FA:FB:..., fill in all
+ * 20 bytes as: { 0x01, 0x02, 0xFA, 0xFB, ... }
+ */
+#define SECRET_MQTT_FINGERPRINT \
+  { 0x.., 0x.., ... }
+/* If you enabled MQTT_AUTH, fill these in as well */
+#define SECRET_MQTT_USER "<your username>"
+#define SECRET_MQTT_PASS "<your passphrase>"

--- a/config.h.example
+++ b/config.h.example
@@ -1,3 +1,10 @@
+/* Define MQTT_TLS to use TLS with pinned certificate for secure MQTT. Put the
+ * SHA1 fingerprint of the server certificate in arduino_secrets.h. */
+//#define MQTT_TLS
+/* Define MQTT_AUTH to use password authentication (only valid when
+ * MQTT_TLS is set). */
+//#define MQTT_AUTH
+
 /* Optionally, if you define OPTIONAL_LIGHT_SENSOR, you may attach a light
  * sensor diode (or photo transistor or whatever) to analog pin A0 and have it
  * monitor the red watt hour pulse LED. This improves the current Watt


### PR DESCRIPTION
Authentication is only allowed on encrypted connections to prevent
sending the password in plaintext.

Note: TLS is pretty hard on the small amount of RAM on an ESP8266. But it has been runnning fine for the last three-and-a-half days here, I haven't seen any issues yet.