### PR TITLE
New: config.h.example, arduino_secrets.h.example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/arduino_secrets.h
 /config.h
 /pe32me162ir_pub.test
 /raw.log

--- a/arduino_secrets.h.example
+++ b/arduino_secrets.h.example
@@ -1,0 +1,5 @@
+#define SECRET_WIFI_SSID "<your ssid>"
+#define SECRET_WIFI_PASS "<your passphrase>"
+#define SECRET_MQTT_BROKER "192.168.1.2"
+#define SECRET_MQTT_PORT 1883
+#define SECRET_MQTT_TOPIC "some/topic"

--- a/config.h.example
+++ b/config.h.example
@@ -1,0 +1,9 @@
+//#define OPTIONAL_LIGHT_SENSOR
+/* Optionally, if you define OPTIONAL_LIGHT_SENSOR, you may attach a light
+ * sensor diode (or photo transistor or whatever) to analog pin A0 and have it
+ * monitor the red watt hour pulse LED. This improves the current Watt
+ * calculation when the power consumption is low. A pulse causes the sleep to
+ * be cut short, increasing the possibility that two consecutive readings are
+ * "right after a new watt hour value."
+ * > In the meter mode it [...] blinks with a pulse rate of 1000 imp/kWh,
+ * > the pulse's width is 40 ms. */

--- a/pe32me162ir_pub.h
+++ b/pe32me162ir_pub.h
@@ -33,4 +33,6 @@
 
 #include "config.h"
 
+#include "arduino_secrets.h"
+
 #endif //INCLUDED_PE32ME162IR_PUB_H


### PR DESCRIPTION
This way a user doesn't have to hunt the main .ino file for a piece of
code to copy-paste. But since `config.h` is still in `.gitignore`, local
configuration will not be overwritten. Whenever the example file
changes, a user can easily diff it to their actual `config.h` and adapt
as necessary.

`arduino_secrets.h` should conform to Arduino's convention of using that
file for secrets and using macro's named `SECRET_*` for the values.

Order of inclusions and global variables etcetera is changed to be more
conventional. This fixes a bug: there's an
`#ifdef OPTIONAL_LIGHT_SENSOR` before including `config.h`, but the user
is told to define it in `config.h`.